### PR TITLE
UCP/EP: support selecting local address for each connection

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -227,7 +227,8 @@ enum ucp_ep_params_field {
     UCP_EP_PARAM_FIELD_USER_DATA         = UCS_BIT(3), /**< User data pointer */
     UCP_EP_PARAM_FIELD_SOCK_ADDR         = UCS_BIT(4), /**< Socket address field */
     UCP_EP_PARAM_FIELD_FLAGS             = UCS_BIT(5), /**< Endpoint flags */
-    UCP_EP_PARAM_FIELD_CONN_REQUEST      = UCS_BIT(6)  /**< Connection request field */
+    UCP_EP_PARAM_FIELD_CONN_REQUEST      = UCS_BIT(6), /**< Connection request field */
+    UCP_EP_PARAM_FIELD_LOCAL_ADDR        = UCS_BIT(7)  /**< Local sock Address */
 };
 
 

--- a/src/ucp/api/ucp_def.h
+++ b/src/ucp/api/ucp_def.h
@@ -612,6 +612,12 @@ typedef struct ucp_ep_params {
      * in client-server connection establishment flow.
      */
     ucs_sock_addr_t         sockaddr;
+    /**
+     * Local address in the form of a sockaddr; this field should be set
+     * along with its corresponding bit in the field_mask - @ref
+     * UCP_EP_PARAM_FIELD_LOCAL_ADDR.
+     */
+    ucs_sock_addr_t         local_addr;
 
     /**
      * Connection request from client; this field should be set along with its

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -501,6 +501,11 @@ ucs_status_t ucp_ep_client_cm_connect_start(ucp_ep_h ucp_ep,
     cm_lane_params.sockaddr_pack_cb           = ucp_cm_client_priv_pack_cb;
     cm_lane_params.sockaddr_connect_cb.client = ucp_cm_client_connect_cb;
     cm_lane_params.disconnect_cb              = ucp_cm_disconnect_cb;
+
+    if (params->field_mask & UCP_EP_PARAM_FIELD_LOCAL_ADDR) {
+        cm_lane_params.field_mask            |= UCT_EP_PARAM_FIELD_LOCAL_ADDR;
+        cm_lane_params.local_addr             = &params->local_addr;
+    }
     ucs_assert_always(ucp_worker_num_cm_cmpts(worker) == 1);
     cm_lane_params.cm                         = worker->cms[0].cm;
 

--- a/src/ucs/sys/sock.c
+++ b/src/ucs/sys/sock.c
@@ -630,6 +630,33 @@ const char* ucs_sockaddr_str(const struct sockaddr *sock_addr,
     return str;
 }
 
+ucs_status_t ucs_sock_ipstr_to_sockaddr(const char *ip_str,
+                                        struct sockaddr_storage *sa_storage)
+{
+    struct sockaddr_in* sa_in;
+    struct sockaddr_in6* sa_in6;
+    int ret;
+
+    /* try IPv4 */
+    sa_in             = (struct sockaddr_in*)sa_storage;
+    sa_in->sin_family = AF_INET;
+    ret = inet_pton(AF_INET, ip_str, &sa_in->sin_addr);
+    if (ret == 1) {
+        return UCS_OK;
+    }
+
+    /* try IPv6 */
+    sa_in6              = (struct sockaddr_in6*)sa_storage;
+    sa_in6->sin6_family = AF_INET6;
+    ret = inet_pton(AF_INET6, ip_str, &sa_in6->sin6_addr);
+    if (ret == 1) {
+        return UCS_OK;
+    }
+
+    ucs_error("invalid address %s", ip_str);
+    return UCS_ERR_INVALID_ADDR;
+}
+
 int ucs_sockaddr_cmp(const struct sockaddr *sa1,
                      const struct sockaddr *sa2,
                      ucs_status_t *status_p)

--- a/src/ucs/sys/sock.h
+++ b/src/ucs/sys/sock.h
@@ -389,6 +389,20 @@ const char* ucs_sockaddr_str(const struct sockaddr *sock_addr,
 
 
 /**
+ * Extract the IP address from a given string and return it as a sockaddr storage.
+ *
+ * @param [in]  ip_str       A string to take IP address from.
+ * @param [out] sa_storage   sockaddr storage filled with the IP address and
+ *                           address family.
+ *
+ * @return UCS_OK if @a ip_str has a valid IP address or UCS_ERR_INVALID_ADDR
+ *         otherwise.
+ */
+ucs_status_t ucs_sock_ipstr_to_sockaddr(const char *ip_str,
+                                        struct sockaddr_storage *sa_storage);
+
+
+/**
  * Check if the address family of the given sockaddr is IPv4 or IPv6
  *
  * @param [in] sa       Pointer to sockaddr structure.

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -798,7 +798,11 @@ enum uct_ep_params_field {
     UCT_EP_PARAM_FIELD_SOCKADDR_DISCONNECT_CB = UCS_BIT(10),
 
     /** Enables @ref uct_ep_params::path_index */
-    UCT_EP_PARAM_FIELD_PATH_INDEX             = UCS_BIT(11)
+    UCT_EP_PARAM_FIELD_PATH_INDEX             = UCS_BIT(11),
+
+    /** Enables @ref uct_ep_params::local_addr */
+    UCT_EP_PARAM_FIELD_LOCAL_ADDR             = UCS_BIT(12)
+
 };
 
 
@@ -1076,6 +1080,13 @@ struct uct_ep_params {
      * @ref UCT_IFACE_FLAG_CONNECT_TO_SOCKADDR capability.
      */
     const ucs_sock_addr_t             *sockaddr;
+    /**
+     * The sockaddr to bind locally. If set, @ref uct_ep_create
+     * will create an endpoint binding with this local sock addr.
+     * @note The interface in this routine requires the
+     * @ref UCT_IFACE_FLAG_CONNECT_TO_SOCKADDR capability.
+     */
+    const ucs_sock_addr_t             *local_addr;
 
     /**
      * @ref uct_cb_flags to indicate @ref uct_ep_params_t::sockaddr_pack_cb

--- a/src/uct/ib/rdmacm/rdmacm_cm.c
+++ b/src/uct/ib/rdmacm/rdmacm_cm.c
@@ -603,9 +603,46 @@ static uct_iface_ops_t uct_rdmacm_cm_iface_ops = {
     .iface_is_reachable       = (uct_iface_is_reachable_func_t)ucs_empty_function_return_zero
 };
 
+static ucs_status_t
+uct_rdmacm_cm_ipstr_to_sockaddr(const char *ip_str, struct sockaddr **saddr_p,
+                                const char *debug_name)
+{
+    struct sockaddr_storage *sa_storage;
+    ucs_status_t status;
+
+    /* NULL-pointer for empty parameter */
+    if (ip_str[0] == '\0') {
+        sa_storage = NULL;
+        goto out;
+    }
+
+    sa_storage = ucs_calloc(1, sizeof(struct sockaddr_storage), debug_name);
+    if (sa_storage == NULL) {
+        status = UCS_ERR_NO_MEMORY;
+        ucs_error("cannot allocate memory for rdmacm source address");
+        goto err;
+    }
+
+    status = ucs_sock_ipstr_to_sockaddr(ip_str, sa_storage);
+    if (status != UCS_OK) {
+        goto err_free;
+    }
+
+out:
+    *saddr_p = (struct sockaddr*)sa_storage;
+    return UCS_OK;
+
+err_free:
+    ucs_free(sa_storage);
+err:
+    return status;
+}
+
 UCS_CLASS_INIT_FUNC(uct_rdmacm_cm_t, uct_component_h component,
                     uct_worker_h worker, const uct_cm_config_t *config)
 {
+    const uct_rdmacm_cm_config_t *rdmacm_config = ucs_derived_of(config,
+                                                                 uct_rdmacm_cm_config_t);
     uct_priv_worker_t *worker_priv;
     ucs_status_t status;
 
@@ -639,11 +676,19 @@ UCS_CLASS_INIT_FUNC(uct_rdmacm_cm_t, uct_component_h component,
         goto err_destroy_ev_ch;
     }
 
+    status = uct_rdmacm_cm_ipstr_to_sockaddr(rdmacm_config->src_addr,
+                                             &self->config.src_addr,
+                                             "rdmacm_src_addr");
+    if (status != UCS_OK) {
+        goto ucs_async_remove_handler;
+    }
     ucs_debug("created rdmacm_cm %p with event_channel %p (fd=%d)",
               self, self->ev_ch, self->ev_ch->fd);
 
     return UCS_OK;
 
+ucs_async_remove_handler:
+    ucs_async_remove_handler(self->ev_ch->fd, 1);
 err_destroy_ev_ch:
     rdma_destroy_event_channel(self->ev_ch);
 err:
@@ -653,6 +698,8 @@ err:
 UCS_CLASS_CLEANUP_FUNC(uct_rdmacm_cm_t)
 {
     ucs_status_t status;
+
+    ucs_free(self->config.src_addr);
 
     status = ucs_async_remove_handler(self->ev_ch->fd, 1);
     if (status != UCS_OK) {

--- a/src/uct/ib/rdmacm/rdmacm_cm.h
+++ b/src/uct/ib/rdmacm/rdmacm_cm.h
@@ -23,8 +23,16 @@ typedef struct uct_rdmacm_cm {
     uct_cm_t                   super;
     struct rdma_event_channel  *ev_ch;
     khash_t(uct_rdmacm_cm_cqs) cqs;
+
+    struct {
+        struct sockaddr        *src_addr;
+    } config;
 } uct_rdmacm_cm_t;
 
+typedef struct uct_rdmacm_cm_config {
+    uct_cm_config_t            super;
+    char                       *src_addr;
+} uct_rdmacm_cm_config_t;
 
 UCS_CLASS_DECLARE_NEW_FUNC(uct_rdmacm_cm_t, uct_cm_t, uct_component_h,
                            uct_worker_h, const uct_cm_config_t *);

--- a/src/uct/ib/rdmacm/rdmacm_md.c
+++ b/src/uct/ib/rdmacm/rdmacm_md.c
@@ -23,6 +23,18 @@ static ucs_config_field_t uct_rdmacm_md_config_table[] = {
   {NULL}
 };
 
+static ucs_config_field_t uct_rdmacm_cm_config_table[] = {
+    {"CM_", "", NULL,
+     ucs_offsetof(uct_rdmacm_cm_config_t, super), UCS_CONFIG_TYPE_TABLE(uct_cm_config_table)},
+
+    {"SOURCE_ADDRESS", "",
+     "If non-empty, specify the local source address (IPv4 or IPv6) to use \n"
+     "when creating a client connection",
+     ucs_offsetof(uct_rdmacm_cm_config_t, src_addr), UCS_CONFIG_TYPE_STRING},
+
+    {NULL}
+};
+
 static void uct_rdmacm_md_close(uct_md_h md);
 
 static uct_md_ops_t uct_rdmacm_md_ops = {
@@ -252,9 +264,9 @@ uct_component_t uct_rdmacm_component = {
     },
     .cm_config          = {
         .name           = "RDMA-CM connection manager",
-        .prefix         = "RDMACM_",
-        .table          = uct_cm_config_table,
-        .size           = sizeof(uct_cm_config_t),
+        .prefix         = "RDMA_CM_",
+        .table          = uct_rdmacm_cm_config_table,
+        .size           = sizeof(uct_rdmacm_cm_config_t),
     },
     .tl_list            = UCT_COMPONENT_TL_LIST_INITIALIZER(&uct_rdmacm_component),
 #if HAVE_RDMACM_QP_LESS

--- a/test/apps/iodemo/ucx_wrapper.cc
+++ b/test/apps/iodemo/ucx_wrapper.cc
@@ -691,8 +691,10 @@ UcxConnection::~UcxConnection()
     --_num_instances;
 }
 
-void UcxConnection::connect(const struct sockaddr *saddr, socklen_t addrlen,
-                            UcxCallback *callback)
+void UcxConnection::connect(const struct sockaddr *src_addr,
+                               const struct sockaddr *saddr,
+                               socklen_t addrlen,
+                               UcxCallback *callback)
 {
     set_log_prefix(saddr, addrlen);
 
@@ -702,6 +704,11 @@ void UcxConnection::connect(const struct sockaddr *saddr, socklen_t addrlen,
     ep_params.flags            = UCP_EP_PARAMS_FLAGS_CLIENT_SERVER;
     ep_params.sockaddr.addr    = saddr;
     ep_params.sockaddr.addrlen = addrlen;
+    if (src_addr) {
+        ep_params.field_mask        |= UCP_EP_PARAM_FIELD_LOCAL_ADDR;
+        ep_params.local_addr.addr    = src_addr;
+        ep_params.local_addr.addrlen = addrlen;
+    }
 
     char sockaddr_str[UCS_SOCKADDR_STRING_LEN];
     UCX_CONN_LOG << "Connecting to "

--- a/test/apps/iodemo/ucx_wrapper.h
+++ b/test/apps/iodemo/ucx_wrapper.h
@@ -256,7 +256,9 @@ public:
 
     ~UcxConnection();
 
-    void connect(const struct sockaddr *saddr, socklen_t addrlen,
+    void connect(const struct sockaddr *src_addr,
+                 const struct sockaddr *saddr,
+                 socklen_t addrlen,
                  UcxCallback *callback);
 
     void accept(ucp_conn_request_h conn_req, UcxCallback *callback);


### PR DESCRIPTION
## What
to support selecting local address for each connection

## Why ?
if users have multiple HCAs on client side, they can select the NIC they want to use (round robin fashion for example)

## How ?
two methods:
1. use env variable UCX_RDMA_CM_SOURCE_ADDRESS to select NIC for all connections in the app
2. specify local address in ucp_ep_params when call ucp_ep_create() for each connection in the app
